### PR TITLE
Added 3 new configuration variables to provide metric views. 

### DIFF
--- a/app/apis/home_assistant_weather_api.rb
+++ b/app/apis/home_assistant_weather_api.rb
@@ -168,9 +168,14 @@ class HomeAssistantWeatherApi < Api
 
     events = []
 
+    metric_wind = @config["speed_format"] == "metric"
+    wind_threshold = metric_wind ? 32.0 : 20.0
+    wind_unit = metric_wind ? "km/h" : "mph"
+
     hours.each do |hour|
-      wind_speed_mph = hour[:wind_speed].to_f * 0.621371 # km/h to mph
-      next if wind_speed_mph < 20.0
+      wind_speed = hour[:wind_speed].to_f
+      wind_speed *= 0.621371 unless metric_wind
+      next if wind_speed < wind_threshold
 
       hour_i = DateTime.parse(hour[:datetime]).to_i
       next if hour_i < Time.now.to_i
@@ -179,13 +184,13 @@ class HomeAssistantWeatherApi < Api
 
       if existing_event
         existing_event[:end_i] += 3600
-        existing_event[:wind_max] = [existing_event[:wind_max], wind_speed_mph].max
+        existing_event[:wind_max] = [existing_event[:wind_max], wind_speed].max
         existing_event[:wind_directions] << hour[:wind_bearing].to_i
       else
         events << {
           start_i: hour_i,
           end_i: hour_i + 3600,
-          wind_max: wind_speed_mph,
+          wind_max: wind_speed,
           wind_directions: [hour[:wind_bearing].to_i]
         }
       end
@@ -203,7 +208,7 @@ class HomeAssistantWeatherApi < Api
         ends_at: it[:end_i],
         icon: "arrow-up",
         icon_rotation: avg_wind_direction,
-        summary: "Gusts up to #{it[:wind_max].round}mph"
+        summary: "Gusts up to #{it[:wind_max].round}#{wind_unit}"
       )
     end
   end

--- a/app/apis/weather_kit_api.rb
+++ b/app/apis/weather_kit_api.rb
@@ -1,6 +1,7 @@
 class WeatherKitApi < Api
-  def initialize(home_assistant_config_api: HomeAssistantConfigApi.new)
+  def initialize(home_assistant_config_api: HomeAssistantConfigApi.new, config: Timeframe::Application.config.local)
     @home_assistant_config_api = home_assistant_config_api
+    @config = config
   end
 
   def fetch
@@ -28,7 +29,7 @@ class WeatherKitApi < Api
 
     return nil unless raw_temp
 
-    "#{celsius_fahrenheit(data.dig(:currentWeather, :temperature))}°"
+    "#{format_temperature(data.dig(:currentWeather, :temperature))}°"
   end
 
   def hourly_calendar_events
@@ -55,7 +56,7 @@ class WeatherKitApi < Api
           starts_at: hour,
           ends_at: hour,
           icon: icon_for(weather_hour[:conditionCode]),
-          summary: "#{celsius_fahrenheit(weather_hour[:temperature])}°".html_safe
+          summary: "#{format_temperature(weather_hour[:temperature])}°".html_safe
         )
       end.compact
     end
@@ -70,9 +71,14 @@ class WeatherKitApi < Api
 
     hours = data[:forecastHourly][:hours]
 
+    metric_wind = @config["speed_format"] == "metric"
+    wind_threshold = metric_wind ? 32.0 : 20.0
+    wind_unit = metric_wind ? "km/h" : "mph"
+
     hours.each do |hour|
-      hour_wind_mph = hour[:windGust].to_f * 0.621371
-      next if hour_wind_mph < 20.0
+      wind_speed = hour[:windGust].to_f
+      wind_speed *= 0.621371 unless metric_wind
+      next if wind_speed < wind_threshold
 
       hour_i = DateTime.parse(hour[:forecastStart]).to_i
 
@@ -83,14 +89,14 @@ class WeatherKitApi < Api
 
       if existing_event
         existing_event[:end_i] += 3600
-        existing_event[:wind_max] = [existing_event[:wind_max], hour_wind_mph].max
+        existing_event[:wind_max] = [existing_event[:wind_max], wind_speed].max
         existing_event[:wind_directions] << hour[:windDirection]
       else
         events <<
           {
             start_i: hour_i,
             end_i: (DateTime.parse(hour[:forecastStart]) + 1.hour).to_i,
-            wind_max: hour_wind_mph,
+            wind_max: wind_speed,
             wind_directions: [hour[:windDirection]]
           }
       end
@@ -109,7 +115,7 @@ class WeatherKitApi < Api
         ends_at: it[:end_i],
         icon: "arrow-up",
         icon_rotation: avg_wind_direction,
-        summary: "Gusts up to #{it[:wind_max].round}mph"
+        summary: "Gusts up to #{it[:wind_max].round}#{wind_unit}"
       )
     end
   end
@@ -215,11 +221,9 @@ class WeatherKitApi < Api
     days.map do |day|
       summary_suffix =
         if day.dig(:precipitationType) == "snow"
-          if day.dig(:snowfallAmount) > 0.05
-            " / #{(day[:snowfallAmount] * 0.0393701).round(1)}\""
-          end
-        elsif (day.dig(:precipitationAmount).to_f * 0.0393701) >= 0.1
-          " / #{(day[:precipitationAmount] * 0.0393701).round(1)}\""
+          format_rainfall(day[:snowfallAmount]) if day.dig(:snowfallAmount) > 0.05
+        elsif day.dig(:precipitationAmount).to_f >= 2.54
+          format_rainfall(day[:precipitationAmount])
         end
 
       CalendarEvent.new(
@@ -227,12 +231,28 @@ class WeatherKitApi < Api
         starts_at: DateTime.parse(day[:forecastStart]).to_i,
         ends_at: DateTime.parse(day[:forecastEnd]).to_i,
         icon: icon_for(day[:conditionCode]),
-        summary: "#{celsius_fahrenheit(day[:temperatureMax])}° / #{celsius_fahrenheit(day[:temperatureMin])}°#{summary_suffix}".html_safe
+        summary: "#{format_temperature(day[:temperatureMax])}° / #{format_temperature(day[:temperatureMin])}°#{summary_suffix}".html_safe
       )
     end
   end
 
-  def celsius_fahrenheit(c)
-    (c * 9 / 5 + 32).round
+  def format_temperature(c)
+    if @config["air_temp_format"] == "metric"
+      c.round
+    else
+      (c * 9 / 5 + 32).round
+    end
+  end
+
+  def format_rainfall(mm)
+    if @config["rainfall_format"] == "metric"
+      if mm >= 10
+        " / #{(mm / 10.0).round(1)}cm"
+      else
+        " / #{mm.round(1)}mm"
+      end
+    else
+      " / #{(mm * 0.0393701).round(1)}\""
+    end
   end
 end

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,3 +1,6 @@
+air_temp_format: imperial
+rainfall_format: imperial
+speed_format: imperial
 home_assistant_token: abcd1234
 apple_developer_team_id:
 apple_developer_service_id:

--- a/test/apis/weather_kit_api_test.rb
+++ b/test/apis/weather_kit_api_test.rb
@@ -41,17 +41,50 @@ class WeatherKitApiTest < Minitest::Test
     end
   end
 
-  def test_current_temperature
+  def test_current_temperature_imperial
     weather = {
       currentWeather: {
         temperature: 30.06
       }
     }
 
-    api = WeatherKitApi.new
+    api = WeatherKitApi.new(config: {"air_temp_format" => "imperial"})
     api.stub :data, weather do
       assert_equal("86°", api.current_temperature)
     end
+  end
+
+  def test_current_temperature_metric
+    weather = {
+      currentWeather: {
+        temperature: 30.06
+      }
+    }
+
+    api = WeatherKitApi.new(config: {"air_temp_format" => "metric"})
+    api.stub :data, weather do
+      assert_equal("30°", api.current_temperature)
+    end
+  end
+
+  def test_format_rainfall_imperial
+    api = WeatherKitApi.new(config: {"rainfall_format" => "imperial"})
+    assert_equal(" / 0.5\"", api.send(:format_rainfall, 12.7))
+  end
+
+  def test_format_rainfall_default_is_imperial
+    api = WeatherKitApi.new(config: {})
+    assert_equal(" / 0.5\"", api.send(:format_rainfall, 12.7))
+  end
+
+  def test_format_rainfall_metric_mm
+    api = WeatherKitApi.new(config: {"rainfall_format" => "metric"})
+    assert_equal(" / 5.2mm", api.send(:format_rainfall, 5.2))
+  end
+
+  def test_format_rainfall_metric_cm
+    api = WeatherKitApi.new(config: {"rainfall_format" => "metric"})
+    assert_equal(" / 1.3cm", api.send(:format_rainfall, 12.7))
   end
 
   def test_health_no_data
@@ -2400,6 +2433,38 @@ class WeatherKitApiTest < Minitest::Test
     end
   end
 
+  def test_weather_wind_calendar_events_imperial
+    weather = {
+      forecastHourly: {
+        hours: [{"forecastStart" => "2099-01-01T06:00:00Z",
+                 "windDirection" => 180,
+                 "windGust" => 48.28}.with_indifferent_access]
+      }
+    }
+
+    api = WeatherKitApi.new(config: {"speed_format" => "imperial"})
+    api.stub :data, weather do
+      event = api.wind_calendar_events.first
+      assert(event.summary.include?("30mph"))
+    end
+  end
+
+  def test_weather_wind_calendar_events_metric
+    weather = {
+      forecastHourly: {
+        hours: [{"forecastStart" => "2099-01-01T06:00:00Z",
+                 "windDirection" => 180,
+                 "windGust" => 48.28}.with_indifferent_access]
+      }
+    }
+
+    api = WeatherKitApi.new(config: {"speed_format" => "metric"})
+    api.stub :data, weather do
+      event = api.wind_calendar_events.first
+      assert(event.summary.include?("48km/h"))
+    end
+  end
+
   # This failure was hidden by a caught error, commenting out for now
   # def test_fetch_raises_no_errors
   #   VCR.use_cassette("weatherkit_fetch") do
@@ -2621,9 +2686,27 @@ class WeatherKitApiTest < Minitest::Test
                       name: "DailyForecast"}
     }
 
-    api = WeatherKitApi.new
+    api = WeatherKitApi.new(config: {"rainfall_format" => "imperial"})
     api.stub :data, weather do
       assert(api.daily_calendar_events.first.summary.include?('2.8"'))
+    end
+  end
+
+  def test_daily_calendar_events_snow_precip_metric
+    weather = {
+      forecastDaily: {days: [{forecastStart: "2024-01-15T07:00:00Z",
+                              forecastEnd: "2024-01-16T07:00:00Z",
+                              conditionCode: "Snow",
+                              precipitationType: "snow",
+                              snowfallAmount: 70.09,
+                              temperatureMax: -16.58,
+                              temperatureMin: -24.15}],
+                      name: "DailyForecast"}
+    }
+
+    api = WeatherKitApi.new(config: {"rainfall_format" => "metric"})
+    api.stub :data, weather do
+      assert(api.daily_calendar_events.first.summary.include?("7.0cm"))
     end
   end
 
@@ -2703,9 +2786,28 @@ class WeatherKitApiTest < Minitest::Test
                       name: "DailyForecast"}
     }
 
-    api = WeatherKitApi.new
+    api = WeatherKitApi.new(config: {"rainfall_format" => "imperial"})
     api.stub :data, weather do
       assert(api.daily_calendar_events.first.summary.include?('0.3"'))
+    end
+  end
+
+  def test_daily_calendar_events_rain_precip_metric
+    weather = {
+      forecastDaily: {days: [{forecastStart: "2024-04-26T06:00:00Z",
+                              forecastEnd: "2024-04-27T06:00:00Z",
+                              conditionCode: "Rain",
+                              precipitationAmount: 7.82,
+                              precipitationType: "rain",
+                              snowfallAmount: 0.0,
+                              temperatureMax: 19.92,
+                              temperatureMin: 8.23}],
+                      name: "DailyForecast"}
+    }
+
+    api = WeatherKitApi.new(config: {"rainfall_format" => "metric"})
+    api.stub :data, weather do
+      assert(api.daily_calendar_events.first.summary.include?("7.8mm"))
     end
   end
 


### PR DESCRIPTION
Added 3 new variables to config.yml.example for controlling how Timeframe displays temperature, rainfall, and wind speed:

```
speed_format: metric
rainfall_format: metric
air_temp_format: metric
```

If these config variables are not specified, Timeframe will continue serving Farenheit/inches/mph values. So any existing Timeframe configuration won't be changed unless the user explicitly sets "metric" to override the default "imperial" view.

Setting any one of these to metric will show that one item in its metric equivalent instead (Celcius/mm(or cm)/kmph)